### PR TITLE
Improve readSMS() + Fix multi-lines SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,7 @@ Watch this repo for new updates! And of course, contributions are welcome ;)
         - XBee, u-blox SARA R4/N4, ESP8266 (obviously)
 
 **SMS**
-- Only _sending_ SMS is supported, not receiving
-    - Supported on all cellular modules
+- Supported on all cellular modules
 
 **Voice Calls**
 - Supported on:

--- a/examples/ReadSMSInterrupt/ReadSMSInterrupt.ino
+++ b/examples/ReadSMSInterrupt/ReadSMSInterrupt.ino
@@ -37,8 +37,9 @@ void loop() {
   }
   int i = Serial.parseInt();
   Serial.print("Reading message at :- ");Serial.println(i);
-  String SMS=modem.readSMS(i);
-  String ID=modem.getSenderID(i);
+  String SMS="";
+  String ID="";
+  modem.readSMS(i, ID, SMS);
   Serial.print("Message From : ");Serial.println(ID);
   Serial.println(" and the message is ");
   Serial.println(SMS);

--- a/src/TinyGsmSMS.tpp
+++ b/src/TinyGsmSMS.tpp
@@ -85,6 +85,12 @@ class TinyGsmSMS {
     thisModem().sendAT(GF("+CMGDA=\"DEL ALL\""));
     return thisModem().waitResponse(60000L) == 1;
   }
+  bool deleteSMS(int index, int delflag=0) {
+    thisModem().sendAT(GF("+CMGF=1"));
+    thisModem().waitResponse(); 
+    thisModem().sendAT(GF("+CMGD="), index, GF(","), delflag);
+    return thisModem().waitResponse(5000L) == 1;
+  }
   String getSenderID(int index, const bool changeStatusToRead = true){
     thisModem().sendAT(GF("+CMGF=1"));
     thisModem().waitResponse(); 

--- a/src/TinyGsmSMS.tpp
+++ b/src/TinyGsmSMS.tpp
@@ -45,6 +45,20 @@ class TinyGsmSMS {
     h=thisModem().stream.readStringUntil('\n');
     return h;
   }
+  String readSMS(int index, String &sender, String &message, const bool changeStatusToRead = true){
+    thisModem().sendAT(GF("+CMGF=1"));
+    thisModem().waitResponse();  
+    thisModem().sendAT(GF("+CMGR="), index, GF(","), static_cast<const uint8_t>(!changeStatusToRead)); 
+    sender = "";
+    message = "";
+    thisModem().streamSkipUntil('"');
+    thisModem().streamSkipUntil('"');
+    thisModem().streamSkipUntil('"');
+    sender = thisModem().stream.readStringUntil('"');
+    thisModem().streamSkipUntil('\n');
+    message = thisModem().stream.readStringUntil('\n');
+    return message;
+  }
   int newMessageIndex(bool mode){
     thisModem().sendAT(GF("+CMGF=1"));
     thisModem().waitResponse();  

--- a/src/TinyGsmSMS.tpp
+++ b/src/TinyGsmSMS.tpp
@@ -42,7 +42,8 @@ class TinyGsmSMS {
     String h="";
     thisModem().streamSkipUntil('\n');
     thisModem().streamSkipUntil('\n');
-    h=thisModem().stream.readStringUntil('\n');
+    h = thisModem().stream.readString();
+    h.remove(h.length()-8, 8);  // Strip trailing "OK" + CR/LF
     return h;
   }
   String readSMS(int index, String &sender, String &message, const bool changeStatusToRead = true){
@@ -56,7 +57,8 @@ class TinyGsmSMS {
     thisModem().streamSkipUntil('"');
     sender = thisModem().stream.readStringUntil('"');
     thisModem().streamSkipUntil('\n');
-    message = thisModem().stream.readStringUntil('\n');
+    message = thisModem().stream.readString();
+    message.remove(message.length()-8, 8);  // Strip trailing "OK" + CR/LF
     return message;
   }
   int newMessageIndex(bool mode){


### PR DESCRIPTION
Hello,

First of all, thanks for your work at implementing the SMS reading.
As your code isn't merged already, i'm opening a PR here.

I improved it a bit by overloading your readSMS function. This way, only one AT+CMGR command is needed to read both the message and the sender_id. Instead of using readSMS() and getSenderID() which each issue an AT+CMGR command.

I also fixed an issue for multi-lines SMS. Only the first line was read.

and then, I edited the Readme as SMS reading is now possible.